### PR TITLE
Variable can start with underscore

### DIFF
--- a/chapter07/x_ex01_underscore.cpp
+++ b/chapter07/x_ex01_underscore.cpp
@@ -156,7 +156,7 @@ Token Token_stream::get()
                 return Token{number, val};
             }
         default:
-            if (isalpha(ch)) {
+            if (isalpha(ch) && ch == '_') {
                 string s;
                 s += ch;
                 // exercise 01


### PR DESCRIPTION
The old version only accepts the variables like "variable_ver", but the new version accepts both "variable_ver" and "_variable_ver".

We mean that the variables now can start with an underscore.
